### PR TITLE
Added CLI command "cache:refresh:invalidated"

### DIFF
--- a/Console/Command/CacheFlushInvalidatedCommand.php
+++ b/Console/Command/CacheFlushInvalidatedCommand.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright © Pronko Consulting (https://www.pronkoconsulting.com)
+ * See LICENSE for the license details.
+ */
+declare(strict_types=1);
+
+namespace Pronko\SelectiveCache\Console\Command;
+
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Manager as EventManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command for flushing invalidated cache types
+ */
+class CacheFlushInvalidatedCommand extends Command
+{
+    /**
+     * @var EventManager
+     */
+    private $eventManager;
+
+    /**
+     * CacheFlushInvalidatedCommand constructor.
+     * @param EventManager $eventManager
+     */
+    public function __construct(
+        EventManager $eventManager
+    ) {
+        $this->eventManager = $eventManager;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('cache:refresh:invalidated');
+        $this->setDescription('Flushes cache storage used by currently invalidated cache type(s)');
+        parent::configure();
+    }
+
+    /**
+     * Flushes invalidated cache types
+     *
+     * @param array $cacheTypes
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var DataObject $cacheContainer */
+        $cacheContainer = new DataObject();
+
+        $this->eventManager
+            ->dispatch(
+                'cache_flush_invalidated',
+                ['cache_container' => $cacheContainer]
+            );
+
+        $output->writeln($this->getDisplayMessage($cacheContainer->getData('labels')));
+    }
+
+    /**
+     * Returns an output message to be displayed on the CLI
+     *
+     * @param array $labels
+     * @return string
+     */
+    protected function getDisplayMessage(array $labels)
+    {
+        if (!empty($labels)) {
+            $message = "Flushed invalidated cache types: \n" . implode("\n", $labels);
+        } else {
+            $message = 'No invalidated caches were found.';
+        }
+
+        return $message;
+    }
+}

--- a/Controller/Adminhtml/Cache/FlushInvalidated.php
+++ b/Controller/Adminhtml/Cache/FlushInvalidated.php
@@ -7,10 +7,16 @@ declare(strict_types=1);
 
 namespace Pronko\SelectiveCache\Controller\Adminhtml\Cache;
 
-use Magento\Framework\App\Action\HttpGetActionInterface;
-use Magento\Framework\DataObject;
-use Magento\Framework\Controller\ResultInterface;
+use Magento\Backend\App\Action;
 use Magento\Backend\Controller\Adminhtml\Cache;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Cache\Frontend\Pool;
+use Magento\Framework\App\Cache\StateInterface;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Manager as EventManager;
+use Magento\Framework\View\Result\PageFactory;
 
 /**
  * Class FlushInvalidated
@@ -23,18 +29,69 @@ class FlushInvalidated extends Cache implements HttpGetActionInterface
      * @see _isAllowed()
      */
     const ADMIN_RESOURCE = 'Pronko_SelectiveCache::flush_invalidated_cache';
+    /**
+     * @var Action\Context
+     */
+    private $context;
+    /**
+     * @var TypeListInterface
+     */
+    private $cacheTypeList;
+    /**
+     * @var StateInterface
+     */
+    private $cacheState;
+    /**
+     * @var Pool
+     */
+    private $cacheFrontendPool;
+    /**
+     * @var EventManager
+     */
+    private $eventManager;
+
+    /**
+     * FlushInvalidated constructor.
+     * @param Action\Context $context
+     * @param TypeListInterface $cacheTypeList
+     * @param StateInterface $cacheState
+     * @param Pool $cacheFrontendPool
+     * @param PageFactory $resultPageFactory
+     * @param EventManager $eventManager
+     */
+    public function __construct(
+        Action\Context $context,
+        TypeListInterface $cacheTypeList,
+        StateInterface $cacheState,
+        Pool $cacheFrontendPool,
+        PageFactory $resultPageFactory,
+        EventManager $eventManager
+    ) {
+        parent::__construct($context, $cacheTypeList, $cacheState, $cacheFrontendPool, $resultPageFactory);
+
+        $this->context = $context;
+        $this->cacheTypeList = $cacheTypeList;
+        $this->cacheState = $cacheState;
+        $this->cacheFrontendPool = $cacheFrontendPool;
+        $this->resultPageFactory = $resultPageFactory;
+        $this->eventManager = $eventManager;
+    }
 
     /**
      * @return ResultInterface
      */
     public function execute()
     {
-        $cacheLabels = [];
-        /** @var DataObject $invalidatedType */
-        foreach ($this->_cacheTypeList->getInvalidated() as $invalidatedType) {
-            $this->_cacheTypeList->cleanType($invalidatedType->getData('id'));
-            $cacheLabels[] = $invalidatedType->getData('cache_type');
-        }
+        /** @var DataObject $cacheContainer */
+        $cacheContainer = new DataObject();
+
+        $this->eventManager
+            ->dispatch(
+                'cache_flush_invalidated',
+                ['cache_container' => $cacheContainer]
+            );
+
+        $cacheLabels = $cacheContainer->getData('labels');
 
         if (!empty($cacheLabels)) {
             $this->messageManager->addSuccessMessage(

--- a/Observer/FlushInvalidatedCache.php
+++ b/Observer/FlushInvalidatedCache.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Pronko Consulting (https://www.pronkoconsulting.com)
+ * See LICENSE for the license details.
+ */
+declare(strict_types=1);
+
+namespace Pronko\SelectiveCache\Observer;
+
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ * Class FlushInvalidatedCache
+ * @package Pronko\SelectiveCache\Observer
+ */
+class FlushInvalidatedCache implements ObserverInterface
+{
+    /**
+     * @var TypeListInterface
+     */
+    protected $_cacheTypeList;
+
+    /**
+     * FlushInvalidatedCache constructor.
+     * @param TypeListInterfaceAlias $cacheTypeList
+     */
+    public function __construct(TypeListInterface $cacheTypeList)
+    {
+        $this->_cacheTypeList = $cacheTypeList;
+    }
+
+    /**
+     * Flush Invalidated cache
+     * 
+     * @param Observer $observer
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var DataObject $cacheContainer */
+        $cacheContainer = $observer->getEvent()->getCacheContainer();
+
+        $cacheLabels = [];
+        /** @var DataObject $invalidatedType */
+        foreach ($this->_cacheTypeList->getInvalidated() as $invalidatedType) {
+            $this->_cacheTypeList->cleanType($invalidatedType->getData('id'));
+            $cacheLabels[] = $invalidatedType->getData('cache_type');
+        }
+        $cacheContainer->setData('labels', $cacheLabels);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -12,4 +12,11 @@
     <type name="Magento\AdminNotification\Model\System\Message\CacheOutdated">
         <plugin name="PronkoSelectiveCacheMessagePlugin" type="Pronko\SelectiveCache\Plugin\CacheOutdatedMessagePlugin" />
     </type>
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="flushInvalidatedCache" xsi:type="object">Pronko\SelectiveCache\Console\Command\CacheFlushInvalidatedCommand</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Pronko Consulting (https://www.pronkoconsulting.com)
+ * See LICENSE for the license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="cache_flush_invalidated">
+        <observer name="flush_invalidated" instance="Pronko\SelectiveCache\Observer\FlushInvalidatedCache"/>
+    </event>
+</config>


### PR DESCRIPTION
A new CLI command has been added to the module. The action to invalidate the module is now being triggered by an observer, so both the CLI command and the admin controller share the same code. The CLI command can be triggered by typing `bin/magento cache:refresh:invalidated`. A list containing the flushed cache storages will be displayed:

![image](https://user-images.githubusercontent.com/9648056/67919533-84445580-fb7f-11e9-843b-42a5b55507c4.png)
